### PR TITLE
Fix `mypy` configuration in `tox.ini`

### DIFF
--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -19,8 +19,6 @@ commands =
     flake8 {posargs:.}
 
 [testenv:type]
-skipsdist = true
-skip_install = true
 deps =
     mypy
     django-stubs


### PR DESCRIPTION
Currently, running `tox -e type` results in a cryptic error about `celery` not being found. This happens because dependencies aren't being installed in the tox virtual env, since `skip_install` is set to true. `mypy` needs dependencies to be installed so that it can get type info from them.

There's a bunch of other errors that are preventing mypy from being adopted into girder 4 projects, but this change will at least allow it to run and report a more sane error.