### PR TITLE
Remove reference to deleted Appendix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -34,8 +34,7 @@
 
       "Work" shall mean the work of authorship, whether in Source or
       Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+      copyright notice that is included in or attached to the work.
 
       "Derivative Works" shall mean any work, whether in Source or Object
       form, that is based on (or derived from) the Work and for which the


### PR DESCRIPTION
It seems there used to be an Appendix with some advice about how to apply a copyright notice, but there's a parenthesis that still refers to that deleted appendix--this PR strikes the parenthesis.