### PR TITLE
RFC: Remove ProductionConfiguration

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
@@ -7,7 +7,6 @@ from composed_configuration import (
     ConfigMixin,
     DevelopmentBaseConfiguration,
     HerokuProductionBaseConfiguration,
-    ProductionBaseConfiguration,
     TestingBaseConfiguration,
 )
 
@@ -38,10 +37,6 @@ class DevelopmentConfiguration({{ cookiecutter.pkg_name.split('_')|map('capitali
 
 
 class TestingConfiguration({{ cookiecutter.pkg_name.split('_')|map('capitalize')|join('') }}Mixin, TestingBaseConfiguration):
-    pass
-
-
-class ProductionConfiguration({{ cookiecutter.pkg_name.split('_')|map('capitalize')|join('') }}Mixin, ProductionBaseConfiguration):
     pass
 
 


### PR DESCRIPTION
I'm wondering if there's value in having two different production configurations in the cookiecutter, or if it's causing confusion.

(CC @danlamanna )