### PR TITLE
Update S3FF extra name

### DIFF
--- a/{{ cookiecutter.project_slug }}/setup.py
+++ b/{{ cookiecutter.project_slug }}/setup.py
@@ -47,7 +47,7 @@ setup(
         'drf-yasg',
         # Production-only
         'django-composed-configuration[prod]>=0.20',
-        'django-s3-file-field[boto3]',
+        'django-s3-file-field[s3]',
         'gunicorn',
     ],
     extras_require={


### PR DESCRIPTION
`django-s3-file-field` has deprecated the `boto3` extra in favor of `s3`. https://github.com/kitware-resonant/django-s3-file-field/releases/tag/v1.0.0

As a result, a deprecation warning is logged when installing a project ejected from the cookiecutter