### PR TITLE
RFC: Use Redis as celery broker in dev environment

### DIFF
--- a/django-resonant-settings/resonant_settings/celery.py
+++ b/django-resonant-settings/resonant_settings/celery.py
@@ -50,9 +50,14 @@ CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 
 # CloudAMQP-suggested settings
 # https://www.cloudamqp.com/docs/celery.html
+
+# If using Heroku Redis addon, consult the connection limits for your tier to see if it's safe
+# to raise this: https://elements.heroku.com/addons/heroku-redis
+# Keep in mind that celery workers may not be the only use of Redis in a deployment.
 CELERY_BROKER_POOL_LIMIT = 1
 CELERY_BROKER_HEARTBEAT = None
 CELERY_BROKER_CONNECTION_TIMEOUT = 30
+# The following settings are only used with the AMQP transport.
 CELERY_EVENT_QUEUE_EXPIRES = 60
 
 # Note, CELERY_WORKER settings could be different on each running worker.

--- a/django-resonant-settings/resonant_settings/celery.py
+++ b/django-resonant-settings/resonant_settings/celery.py
@@ -2,14 +2,12 @@
 Configure Celery with the following features:
 * Disable the results backend
 * Ensure that tasks will never be lost, but tasks themselves must be idempotent
-* Optimize the network connection to CloudAMQP
 
 This requires the `celery` package to be installed.
 """
 
 from resonant_settings._env import env
 
-# Assume AMQP.
 CELERY_BROKER_URL: str = env.str("DJANGO_CELERY_BROKER_URL")
 
 # Disable results backend, as this feature has too many weaknesses.
@@ -48,17 +46,12 @@ CELERY_WORKER_CANCEL_LONG_RUNNING_TASKS_ON_CONNECTION_LOSS = True
 # This is the default, but is necessary to suppress warnings in Celery
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 
-# CloudAMQP-suggested settings
-# https://www.cloudamqp.com/docs/celery.html
-
 # If using Heroku Redis addon, consult the connection limits for your tier to see if it's safe
 # to raise this: https://elements.heroku.com/addons/heroku-redis
 # Keep in mind that celery workers may not be the only use of Redis in a deployment.
 CELERY_BROKER_POOL_LIMIT = 1
 CELERY_BROKER_HEARTBEAT = None
 CELERY_BROKER_CONNECTION_TIMEOUT = 30
-# The following settings are only used with the AMQP transport.
-CELERY_EVENT_QUEUE_EXPIRES = 60
 
 # Note, CELERY_WORKER settings could be different on each running worker.
 

--- a/{{ cookiecutter.project_slug }}/dev/.env.docker-compose
+++ b/{{ cookiecutter.project_slug }}/dev/.env.docker-compose
@@ -1,5 +1,5 @@
 DJANGO_SETTINGS_MODULE={{ cookiecutter.pkg_name }}.settings.development
 DJANGO_DATABASE_URL=postgres://postgres:postgres@postgres:5432/django
-DJANGO_CELERY_BROKER_URL=amqp://rabbitmq:5672/
+DJANGO_CELERY_BROKER_URL=redis://redis:6379/0
 DJANGO_MINIO_STORAGE_URL=http://minioAccessKey:minioSecretKey@minio:9000/django-storage
 DJANGO_MINIO_STORAGE_MEDIA_URL=http://localhost:9000/django-storage

--- a/{{ cookiecutter.project_slug }}/dev/.env.docker-compose-native
+++ b/{{ cookiecutter.project_slug }}/dev/.env.docker-compose-native
@@ -1,4 +1,4 @@
 DJANGO_SETTINGS_MODULE={{ cookiecutter.pkg_name }}.settings.development
 DJANGO_DATABASE_URL=postgres://postgres:postgres@localhost:5432/django
-DJANGO_CELERY_BROKER_URL=amqp://localhost:5672/
+DJANGO_CELERY_BROKER_URL=redis://localhost:6379/0
 DJANGO_MINIO_STORAGE_URL=http://minioAccessKey:minioSecretKey@localhost:9000/django-storage

--- a/{{ cookiecutter.project_slug }}/docker-compose.override.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.override.yml
@@ -13,7 +13,7 @@ services:
       - 8000:8000
     depends_on:
       - postgres
-      - rabbitmq
+      - redis
       - minio
 
   celery:
@@ -34,5 +34,5 @@ services:
       - .:/opt/django-project
     depends_on:
       - postgres
-      - rabbitmq
+      - redis
       - minio

--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -12,10 +12,10 @@ services:
 
   redis:
     image: redis:alpine
-    volumes:
-      - redis-data:/data
     ports:
       - 6379:6379
+    volumes:
+      - redis-data:/data
 
   minio:
     image: minio/minio:latest

--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -10,13 +10,12 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 
-  rabbitmq:
-    image: rabbitmq:management-alpine
-    ports:
-      - 5672:5672
-      - 15672:15672
+  redis:
+    image: redis:latest
     volumes:
-      - rabbitmq:/var/lib/rabbitmq
+      - redis-data:/redis/data
+    ports:
+      - 6379:6379
 
   minio:
     image: minio/minio:latest
@@ -35,4 +34,4 @@ services:
 volumes:
   postgres:
   minio:
-  rabbitmq:
+  redis-data:

--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - 6379:6379
     volumes:
-      - redis-data:/data
+      - redis:/data
 
   minio:
     image: minio/minio:latest
@@ -34,4 +34,4 @@ services:
 volumes:
   postgres:
   minio:
-  redis-data:
+  redis:

--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -11,9 +11,9 @@ services:
       - postgres:/var/lib/postgresql/data
 
   redis:
-    image: redis:latest
+    image: redis:alpine
     volumes:
-      - redis-data:/redis/data
+      - redis-data:/data
     ports:
       - 6379:6379
 

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.0"
 requires-python = ">=3.13"
 license = { text = "Apache 2.0" }
 dependencies = [
-  "celery",
+  "celery[redis]",
   "django[argon2]",
   "django-allauth",
   "django-auth-style",

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/heroku_production.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/heroku_production.py
@@ -2,7 +2,7 @@ import os
 
 # Redefine these before importing the rest of the settings
 os.environ['DJANGO_DATABASE_URL'] = os.environ['DATABASE_URL']
-os.environ['DJANGO_CELERY_BROKER_URL'] = os.environ['CLOUDAMQP_URL']
+os.environ['DJANGO_CELERY_BROKER_URL'] = os.environ['REDIS_URL']
 # Provided by https://github.com/ianpurvis/heroku-buildpack-version
 os.environ['DJANGO_SENTRY_RELEASE'] = os.environ['SOURCE_VERSION']
 


### PR DESCRIPTION
This change is sufficient to switch celery to Redis in development.

For our standard deployment, using Redis will depend on https://github.com/kitware-resonant/django-composed-configuration/pull/213 and a not yet complete PR to our terraform module that I'll link to this later.