### PR TITLE
Update Docker usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
         cookiecutter-variables: ["include_example_code=yes", "include_example_code=no"]
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:alpine
         env:
           POSTGRES_DB: django
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
       rabbitmq:
-        image: rabbitmq:management
+        image: rabbitmq:management-alpine
         ports:
           - 5672:5672
       minio:

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:alpine
         env:
           POSTGRES_DB: django
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
       rabbitmq:
-        image: rabbitmq:management
+        image: rabbitmq:management-alpine
         ports:
           - 5672:5672
       minio:

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -46,26 +46,6 @@ but allows developers to run Python code on their native system.
 4. When finished, run `docker compose stop`
 5. To destroy the stack and start fresh, run `docker compose down -v`
 
-## Remap Service Ports (optional)
-Attached services may be exposed to the host system via alternative ports. Developers who work
-on multiple software projects concurrently may find this helpful to avoid port conflicts.
-
-To do so, before running any `docker compose` commands, set any of the environment variables:
-* `DOCKER_POSTGRES_PORT`
-* `DOCKER_RABBITMQ_PORT`
-* `DOCKER_MINIO_PORT`
-
-The Django server must be informed about the changes:
-* When running the "Develop with Docker" configuration, override the environment variables:
-  * `DJANGO_MINIO_STORAGE_MEDIA_URL`, using the port from `DOCKER_MINIO_PORT`.
-* When running the "Develop Natively" configuration, override the environment variables:
-  * `DJANGO_DATABASE_URL`, using the port from `DOCKER_POSTGRES_PORT`
-  * `DJANGO_CELERY_BROKER_URL`, using the port from `DOCKER_RABBITMQ_PORT`
-  * `DJANGO_MINIO_STORAGE_ENDPOINT`, using the port from `DOCKER_MINIO_PORT`
-
-Since most of Django's environment variables contain additional content, use the values from
-the appropriate `dev/.env.docker-compose*` file as a baseline for overrides.
-
 ## Testing
 ### Initial Setup
 tox is used to execute all tests.

--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - 5672:5672
       - 15672:15672
     volumes:
-      - rabbitmq:/var/lib/rabbitmq/mnesia
+      - rabbitmq:/var/lib/rabbitmq
 
   minio:
     image: minio/minio:latest

--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -5,15 +5,15 @@ services:
       POSTGRES_DB: django
       POSTGRES_PASSWORD: postgres
     ports:
-      - ${DOCKER_POSTGRES_PORT-5432}:5432
+      - 5432:5432
     volumes:
       - postgres:/var/lib/postgresql/data
 
   rabbitmq:
     image: rabbitmq:management
     ports:
-      - ${DOCKER_RABBITMQ_PORT-5672}:5672
-      - ${DOCKER_RABBITMQ_CONSOLE_PORT-15672}:15672
+      - 5672:5672
+      - 15672:15672
     volumes:
       - rabbitmq:/var/lib/rabbitmq/mnesia
 
@@ -21,13 +21,13 @@ services:
     image: minio/minio:latest
     # When run with a TTY, minio prints credentials on startup
     tty: true
-    command: ["server", "/data", "--console-address", ":${DOCKER_MINIO_CONSOLE_PORT-9001}"]
+    command: ["server", "/data", "--console-address", ":9001"]
     environment:
       MINIO_ROOT_USER: minioAccessKey
       MINIO_ROOT_PASSWORD: minioSecretKey
     ports:
-      - ${DOCKER_MINIO_PORT-9000}:9000
-      - ${DOCKER_MINIO_CONSOLE_PORT-9001}:9001
+      - 9000:9000
+      - 9001:9001
     volumes:
       - minio:/data
 

--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   postgres:
     image: postgres:alpine
+    shm_size: 128mb
     environment:
       POSTGRES_DB: django
       POSTGRES_PASSWORD: postgres

--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:alpine
     environment:
       POSTGRES_DB: django
       POSTGRES_PASSWORD: postgres
@@ -10,7 +10,7 @@ services:
       - postgres:/var/lib/postgresql/data
 
   rabbitmq:
-    image: rabbitmq:management
+    image: rabbitmq:management-alpine
     ports:
       - 5672:5672
       - 15672:15672


### PR DESCRIPTION
* Remove remapping of Docker service ports
  * This feature is not being used and adds too much complexity. When it was first requested, we assumed it would be more burdensome to start and stop projects, so running multiple projects in parallel was more beneficial.
* Use Alpine-based Docker images for services
  * These images will not be extended, so the lack of tooling in Alpine is not an issue.
* Use the correct volume path for the "rabbitmq" Docker image
  * This is taken from the Dockerfile of this image.
* Run the "postgres" Docker container with more memory
  * This is recommended by the upstream readme.