### PR TITLE
Remove explicit setting of "OAUTH2_PROVIDER.PKCE_REQUIRED"

### DIFF
--- a/django-resonant-settings/resonant_settings/oauth_toolkit.py
+++ b/django-resonant-settings/resonant_settings/oauth_toolkit.py
@@ -10,7 +10,6 @@ This requires the `django-oauth-toolkit` package to be installed.
 from datetime import timedelta
 
 OAUTH2_PROVIDER = {
-    "PKCE_REQUIRED": True,
     "ALLOWED_REDIRECT_URI_SCHEMES": ["https"],
     # Don't require users to re-approve scopes each time
     "REQUEST_APPROVAL_PROMPT": "auto",


### PR DESCRIPTION
This is now the default upstream, as of django-oauth-toolkit 2.4.0.