### PR TITLE
Don't use 64-bit primary keys

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/base.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/base.py
@@ -73,7 +73,6 @@ DATABASES = {
         'CONN_MAX_AGE': timedelta(minutes=10).total_seconds(),
     }
 }
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 STORAGES = {
     # Inject the default storage in particular run configurations

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0002_initial_models.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0002_initial_models.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     'id',
-                    models.BigAutoField(
+                    models.AutoField(
                         auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
                     ),
                 ),


### PR DESCRIPTION
64-bit primary keys are probably excessive and may be introducing additional performance penalties.

This will require a more complicated migration to downstream: https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field