### PR TITLE
Add INTERNAL_IPS setting

### DIFF
--- a/{{ cookiecutter.project_slug }}/dev/.env.docker-compose
+++ b/{{ cookiecutter.project_slug }}/dev/.env.docker-compose
@@ -3,3 +3,9 @@ DJANGO_DATABASE_URL=postgres://postgres:postgres@postgres:5432/django
 DJANGO_CELERY_BROKER_URL=amqp://rabbitmq:5672/
 DJANGO_MINIO_STORAGE_URL=http://minioAccessKey:minioSecretKey@minio:9000/django-storage
 DJANGO_MINIO_STORAGE_MEDIA_URL=http://localhost:9000/django-storage
+# When in Docker, the bridge network sends requests from the host machine exclusively via a
+# dedicated IP address. Since there's no way to determine the real origin address,
+# consider any IP address (though actually this will only be the single dedicated address) to
+# be internal. This relies on the host to set up appropriate firewalls for Docker, to prevent
+# access from non-internal addresses.
+DJANGO_INTERNAL_IPS=0.0.0.0/0

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
   "django-debug-toolbar",
   "django-minio-storage",
   "django-s3-file-field[minio]",
+  "iptools",
   "ipython",
   "tox",
 ]

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/development.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/development.py
@@ -1,3 +1,5 @@
+import iptools
+
 from .testing import *
 
 # Import these afterwards, to override
@@ -27,6 +29,10 @@ MIDDLEWARE += [
 # to add new settings as individual feature flags.
 DEBUG = True
 
+# This is typically only overridden when running from Docker.
+INTERNAL_IPS = iptools.IpRangeList(
+    *env.list('DJANGO_INTERNAL_IPS', cast=str, default=['127.0.0.1'])
+)
 CORS_ORIGIN_REGEX_WHITELIST = env.list(
     'DJANGO_CORS_ORIGIN_REGEX_WHITELIST',
     cast=str,


### PR DESCRIPTION
This is essential for the [`django.template.context_processors.debug` template context processor](https://docs.djangoproject.com/en/5.0/ref/templates/api/#django-template-context-processors-debug) to work when Django is running inside Docker. Otherwise, [`INTERNAL_IPS` really doesn't need to be set](https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-INTERNAL_IPS).

I'm not sure if anyone is even using the functionality from `django.template.context_processors.debug`, but I don't like that it's installed but would be broken when developing within Docker.

See https://github.com/django-commons/django-debug-toolbar/issues/1928 for more context.