### PR TITLE
Remove pytest-factoryboy

### DIFF
--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -54,7 +54,6 @@ deps =
     factory-boy
     pytest
     pytest-django
-    pytest-factoryboy
     pytest-mock
 commands =
     pytest {posargs}

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/conftest.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/conftest.py
@@ -1,8 +1,10 @@
+from django.contrib.auth.models import User
 import pytest
-from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
 {% if cookiecutter.include_example_code == 'yes' -%}
+from {{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.models import Image
+
 from .factories import ImageFactory, UserFactory
 {%- else -%}
 from .factories import UserFactory
@@ -22,6 +24,12 @@ def authenticated_api_client(user) -> APIClient:
 
 
 {% if cookiecutter.include_example_code == 'yes' -%}
-register(ImageFactory)
+@pytest.fixture
+def image() -> Image:
+    return ImageFactory()
+
+
 {% endif -%}
-register(UserFactory)
+@pytest.fixture
+def user() -> User:
+    return UserFactory()

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/test_image.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/test_image.py
@@ -1,9 +1,11 @@
 import pytest
 
+from .factories import ImageFactory
 
-def test_image_checksum(image_factory):
+
+def test_image_checksum():
     # Use "build" strategy, so database is not required
-    image = image_factory.build()
+    image = ImageFactory.build()
     image.compute_checksum()
     assert image.checksum is not None
 


### PR DESCRIPTION
This package is fundamentally broken when creating non-trivial factories. Although it provides a slightly easier syntax for creating basic tests, it's likely to break in confusing ways as a project grows.