### PR TITLE
Explicitly set CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP

### DIFF
--- a/django-resonant-settings/resonant_settings/celery.py
+++ b/django-resonant-settings/resonant_settings/celery.py
@@ -45,8 +45,7 @@ CELERY_TASK_ACKS_ON_FAILURE_OR_TIMEOUT = True
 # and this will be Celery's default in 6.0.
 CELERY_WORKER_CANCEL_LONG_RUNNING_TASKS_ON_CONNECTION_LOSS = True
 
-# If Celery can't connect to the broker, keep retrying the connection until it succeeds.
-# This is Celery's default.
+# This is the default, but is necessary to suppress warnings in Celery
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 
 # CloudAMQP-suggested settings

--- a/django-resonant-settings/resonant_settings/celery.py
+++ b/django-resonant-settings/resonant_settings/celery.py
@@ -45,6 +45,10 @@ CELERY_TASK_ACKS_ON_FAILURE_OR_TIMEOUT = True
 # and this will be Celery's default in 6.0.
 CELERY_WORKER_CANCEL_LONG_RUNNING_TASKS_ON_CONNECTION_LOSS = True
 
+# If Celery can't connect to the broker, keep retrying the connection until it succeeds.
+# This is Celery's default.
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+
 # CloudAMQP-suggested settings
 # https://www.cloudamqp.com/docs/celery.html
 CELERY_BROKER_POOL_LIMIT = 1


### PR DESCRIPTION
Celery logs a warning to the console if this setting is not explicitly configured.