### PR TITLE
Support Python >= 3.10 for django-resonant-settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version-file: "{{ cookiecutter.project_slug }}/.python-version"
+          python-version: "3.10"
       - name: Install Python packages
         run: |
           pip install --upgrade pip

--- a/django-resonant-settings/pyproject.toml
+++ b/django-resonant-settings/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "django-resonant-settings"
 description = "Shared Django settings for Resonant applications."
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 license = { text = "Apache 2.0" }
 maintainers = [{ name = "Kitware, Inc.", email = "kitware@kitware.com" }]
 keywords = [
@@ -25,6 +25,9 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python",
 ]
@@ -53,7 +56,7 @@ raw-options = { root = ".." }
 
 [tool.black]
 line-length = 100
-target-version = ["py313"]
+target-version = ["py310"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This allows downstream projects wishing to use an older Django to not be blocked by `django resonant-settings` refusing to install.