### PR TITLE
Declare development tools in dependency groups

### DIFF
--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -41,6 +41,34 @@ dev = [
   "tox",
 ]
 
+[dependency-groups]
+lint = [
+  "flake8",
+  "flake8-black",
+  "flake8-bugbear",
+  "flake8-docstrings",
+  "flake8-isort",
+  "flake8-quotes",
+  "pep8-naming",
+]
+format = [
+  "black",
+  "isort",
+]
+type = [
+  "mypy",
+  {include-group = "test"},
+  "celery-types",
+  "django-stubs[compatible-mypy]",
+  "djangorestframework-stubs",
+]
+test = [
+  "factory-boy",
+  "pytest",
+  "pytest-django",
+  "pytest-mock",
+]
+
 [tool.hatch.build]
 packages = [
   "{{ cookiecutter.project_slug }}",

--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-# Don't use "min_version", to ensure Tox 3 respects this
-minversion = 4
+min_version = 4.22
 env_list =
     lint,
     type,
@@ -17,22 +16,15 @@ extras =
 
 [testenv:lint]
 package = skip
-deps =
-    flake8
-    flake8-black
-    flake8-bugbear
-    flake8-docstrings
-    flake8-isort
-    flake8-quotes
-    pep8-naming
+dependency_groups =
+    lint
 commands =
     flake8 .
 
 [testenv:format]
 package = skip
-deps =
-    black
-    isort
+dependency_groups =
+    format
 commands =
     isort .
     black .
@@ -40,21 +32,14 @@ commands =
 [testenv:type]
 # Editable ensures dependencies are installed, but full packaging isn't necessary
 package = editable
-deps =
-    mypy
-    {[testenv:test]deps}
-    celery-types
-    django-stubs[compatible-mypy]
-    djangorestframework-stubs
+dependency_groups =
+    type
 commands =
     mypy {posargs}
 
 [testenv:test]
-deps =
-    factory-boy
-    pytest
-    pytest-django
-    pytest-mock
+dependency_groups =
+    test
 commands =
     pytest {posargs}
 


### PR DESCRIPTION
This is recommended by Tox, will make it easier to install tooling into development environments, and perfectly fits the use case outlined by PEP 735.