### PR TITLE
Copy pyproject.toml (instead of setup.py) during docker image build

### DIFF
--- a/{{ cookiecutter.project_slug }}/dev/django.Dockerfile
+++ b/{{ cookiecutter.project_slug }}/dev/django.Dockerfile
@@ -3,11 +3,11 @@ FROM python:3.13-slim
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-# Only copy the setup.py, it will still force all install_requires to be installed,
+# Only copy the pyproject.toml, it will still force all install_requires to be installed,
 # but find_packages() will find nothing (which is fine). When Docker Compose mounts the real source
 # over top of this directory, the .egg-link in site-packages resolves to the mounted directory
 # and all package modules are importable.
-COPY ./setup.py /opt/django-project/setup.py
+COPY ./pyproject.toml /opt/django-project/pyproject.toml
 RUN pip install --editable /opt/django-project[dev]
 
 # Use a directory name which will never be an import name, as isort considers this as first-party.


### PR DESCRIPTION
Since this cookiecutter makes use of `pyproject.toml` instead of `setup.py`, the `dev/django.Dockerfile` fails when building, due to it referencing `setup.py` (which doesn't exist) instead of `pyproject.toml`.