### PR TITLE
Mount the full source tree during Docker image build

### DIFF
--- a/{{ cookiecutter.project_slug }}/dev/django.Dockerfile
+++ b/{{ cookiecutter.project_slug }}/dev/django.Dockerfile
@@ -3,12 +3,9 @@ FROM python:3.13-slim
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-# Only copy the pyproject.toml, it will still force all install_requires to be installed,
-# but find_packages() will find nothing (which is fine). When Docker Compose mounts the real source
-# over top of this directory, the .egg-link in site-packages resolves to the mounted directory
-# and all package modules are importable.
-COPY ./pyproject.toml /opt/django-project/pyproject.toml
-RUN pip install --editable /opt/django-project[dev]
+# Docker Compose will also mount this at runtime.
+RUN --mount=source=.,target=/opt/django-project \
+    pip install --no-cache-dir --editable /opt/django-project[dev]
 
 # Use a directory name which will never be an import name, as isort considers this as first-party.
 WORKDIR /opt/django-project


### PR DESCRIPTION
This is allowed by the newer BuildKit capabilities of Docker. This results in a less fragile build process, as all the same files are available for both build and run.