### PR TITLE
Make development settings inherit directly from base, rather than testing

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/development.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/development.py
@@ -1,6 +1,6 @@
 import iptools
 
-from .testing import *
+from .base import *
 
 # Import these afterwards, to override
 from resonant_settings.development.celery import *  # isort: skip
@@ -29,6 +29,8 @@ MIDDLEWARE += [
 # to add new settings as individual feature flags.
 DEBUG = True
 
+SECRET_KEY = 'insecure-secret'
+
 # This is typically only overridden when running from Docker.
 INTERNAL_IPS = iptools.IpRangeList(
     *env.list('DJANGO_INTERNAL_IPS', cast=str, default=['127.0.0.1'])
@@ -38,6 +40,11 @@ CORS_ORIGIN_REGEX_WHITELIST = env.list(
     cast=str,
     default=[r'^http://localhost:\d+$', r'^http://127\.0\.0\.1:\d+$'],
 )
+
+STORAGES['default'] = {
+    'BACKEND': 'minio_storage.storage.MinioMediaStorage',
+}
+from resonant_settings.testing.minio_storage import *  # isort: skip
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/testing.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/testing.py
@@ -2,9 +2,8 @@ from .base import *
 
 SECRET_KEY = 'insecure-secret'
 
-# Use a fast, insecure hasher to speed up tests, but keep existing hashers for development use
-# when reading a production databases.
-PASSWORD_HASHERS.insert(0, 'django.contrib.auth.hashers.MD5PasswordHasher')
+# Use a fast, insecure hasher to speed up tests
+PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
 
 STORAGES['default'] = {
     'BACKEND': 'minio_storage.storage.MinioMediaStorage',


### PR DESCRIPTION
This may lead to some slight configuration duplication, but may make it easier to understand where the correct place for settings should be.

This fixes a bug where the MinIO bucket name was not respected in development.