### PR TITLE
Add preliminary support for devcontainers

### DIFF
--- a/{{ cookiecutter.project_slug }}/.devcontainer/bootstrap-devcontainer.sh
+++ b/{{ cookiecutter.project_slug }}/.devcontainer/bootstrap-devcontainer.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -exu
+
+echo 'alias serve="uv run ./manage.py runserver 0.0.0.0:8000"' >> ~/.bashrc

--- a/{{ cookiecutter.project_slug }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.project_slug }}/.devcontainer/devcontainer.json
@@ -1,0 +1,56 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+    "name": "{{ cookiecutter.project_slug }} Django",
+    "dockerComposeFile": [
+        "../docker-compose.yml",
+        "../docker-compose.override.yml"
+    ],
+    "service": "django",
+    "overrideCommand": true,
+    "workspaceFolder": "/home/vscode/django-project",
+    "features": {
+        "ghcr.io/nils-geistmann/devcontainers-features/zsh:0": {},
+        "ghcr.io/meaningful-ooo/devcontainer-features/fish:2": {},
+        // TODO does this also give the extension? :-/
+        //"ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/devcontainers-extra/features/heroku-cli:1": {},
+        // TODO asks for fingerprint confirmation maybe?
+        "ghcr.io/devcontainers/features/git-lfs:1": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.debugpy",
+                "ms-python.vscode-pylance"
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/home/vscode/uv-env/bin/python",
+                "python.testing.pytestEnabled": true,
+                // TODO: figure out coverage
+                "testing.coverageToolbarEnabled": true,
+                "python.analysis.autoImportCompletions": true
+            }
+        }
+    },
+    "portsAttributes": {
+        "8000": {
+            "name": "Django",
+            "onAutoForward": "ignore"
+        },
+        "9000": {
+            "name": "MinIO",
+            "onAutoForward": "ignore"
+        },
+        "9001": {
+            "name": "MinIO Console",
+            "onAutoForward": "ignore"
+        }
+    },
+    "updateContentCommand": [
+        "uv",
+        "sync"
+    ]
+}

--- a/{{ cookiecutter.project_slug }}/.vscode/launch.json
+++ b/{{ cookiecutter.project_slug }}/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Django Script",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/manage.py",
+      "args": [
+        "${fileBasenameNoExtension}"
+      ],
+      "django": true,
+      "justMyCode": false
+    },
+    {
+      "name": "Python: Django original",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/manage.py",
+      "args": [
+        "runserver_plus",
+        "--print-sql",
+        "0.0.0.0:8000"
+      ],
+      "django": true,
+      "justMyCode": false
+    },
+    {
+      "name": "Python: Debug Tests",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "purpose": [
+        "debug-test"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    }
+  ]
+}

--- a/{{ cookiecutter.project_slug }}/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN mv /root/.local/bin/uv /usr/local/bin/uv
+RUN mv /root/.local/bin/uvx /usr/local/bin/uvx
+
+USER vscode
+
+RUN mkdir /home/vscode/uv
+
+WORKDIR /home/vscode/django-project

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -1,6 +1,19 @@
 # {{ cookiecutter.project_name }}
 
-## Develop with Docker (recommended quickstart)
+## Develop with VSCode Dev Containers (recommended quickstart)
+
+### Initial Setup
+1. Follow the steps for [setting up Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers#_installation) if necessary.
+1. From VSCode, use `Ctrl-Shift-p` and run the command `Dev Containers: Reopen in Container`.
+1. From the VSCode built-in terminal, run `uv run ./manage.py migrate`.
+1. From the VSCode built-in terminal, run `uv run ./manage.py createsuperuser`.
+
+### Run Application
+1. Run `serve` from the VSCode built-in-terminal.
+1. Access the site, starting at http://localhost:8000/admin/
+1. When finished, use `Ctrl+C`
+
+## Develop with Docker
 This is the simplest configuration for developers to start with.
 
 ### Initial Setup

--- a/{{ cookiecutter.project_slug }}/docker-compose.override.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.override.yml
@@ -1,6 +1,8 @@
 services:
   django:
-    image: ghcr.io/astral-sh/uv:debian
+    build:
+      context: .
+      dockerfile: Dockerfile
     command: [
       "uv", "run",
       "./manage.py",
@@ -10,16 +12,16 @@ services:
     tty: false
     environment:
       PYTHONUNBUFFERED: 1
-      UV_PROJECT_ENVIRONMENT: /var/lib/venv
-      UV_CACHE_DIR: /var/cache/uv/cache
-      UV_PYTHON_INSTALL_DIR: /var/cache/uv/bin
+      UV_PROJECT_ENVIRONMENT: /home/vscode/uv-env
+      UV_CACHE_DIR: /home/vscode/uv/cache
+      UV_PYTHON_INSTALL_DIR: /home/vscode/uv/bin
       # The uv cache and environment are on different volumes, so hardlinks won't work
       UV_LINK_MODE: copy
     env_file: ./dev/.env.docker-compose
-    working_dir: /opt/django-project
+    working_dir: /home/vscode/django-project
     volumes:
-      - .:/opt/django-project
-      - uv_cache:/var/cache/uv
+      - .:/home/vscode/django-project
+      - uv_cache:/home/vscode/uv
     ports:
       - 8000:8000
     depends_on:
@@ -28,29 +30,32 @@ services:
       - minio
 
   celery:
-    image: ghcr.io/astral-sh/uv:debian
+    build:
+      context: .
+      dockerfile: Dockerfile
     command: [
       "uv",
       "run",
       "celery",
-      "--app", "{{ cookiecutter.pkg_name }}.celery",
+      "--app", "{{ cookiecutter.project_slug }}.celery",
       "worker",
       "--loglevel", "INFO",
       "--without-heartbeat"
     ]
-    # Docker Compose does not set the TTY width, which causes Celery errors
+    # uv progress doesn't display properly with a Docker TTY
     tty: false
     environment:
       PYTHONUNBUFFERED: 1
-      UV_PROJECT_ENVIRONMENT: /var/lib/venv
-      UV_CACHE_DIR: /var/cache/uv/cache
-      UV_PYTHON_INSTALL_DIR: /var/cache/uv/bin
+      UV_PROJECT_ENVIRONMENT: /home/vscode/uv-env
+      UV_CACHE_DIR: /home/vscode/uv/cache
+      UV_PYTHON_INSTALL_DIR: /home/vscode/uv/bin
+      # The uv cache and environment are on different volumes, so hardlinks won't work
       UV_LINK_MODE: copy
     env_file: ./dev/.env.docker-compose
-    working_dir: /opt/django-project
+    working_dir: /home/vscode/django-project
     volumes:
-      - .:/opt/django-project
-      - uv_cache:/var/cache/uv
+      - .:/home/vscode/django-project
+      - uv_cache:/home/vscode/uv
     depends_on:
       - postgres
       - rabbitmq


### PR DESCRIPTION
This adds preliminary support for [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers). This should work with VSCode and its variants.

A number of things still need to be considered before merging:
- [ ] Support for macOS (cc @zachmullen)
- [ ] Determining a the final list of extensions/features/settings that should be added
- [ ] Ensure all of the DX features work
    - [X] Debugging
    - [ ] Real time errors for typing/linting
    - [X] Auto-import
    - [X] Jump to definition/symbol searching
    - [ ] Coverage display
- [ ] Ensure we're being a good enough citizen that this works well in codespaces
- [ ] Figure out to what extent we want to support [multiple containers](https://code.visualstudio.com/remote/advancedcontainers/connect-multiple-containers) for items like celery
- [ ] Figure out the extent to which we want to support persistent history: https://code.visualstudio.com/remote/advancedcontainers/persist-bash-history

Random ideas for extensions/feature/packages etc:
- Extensions
   - Liveshare
   - GitLens
   - EditorConfig
   - SQL tools
   - TOML mode
   - shellcheck
   - markdown
 - Features (https://containers.dev/features)
   - node
   - boto/aws-cli
   - postgres-client (e.g. `./manage.py dbshell` currently requires `psql`)