### PR TITLE
Enable debugging of Resonant celery tasks via a launch configuration

### DIFF
--- a/{{ cookiecutter.project_slug }}/.vscode/launch.json
+++ b/{{ cookiecutter.project_slug }}/.vscode/launch.json
@@ -26,6 +26,22 @@
       "justMyCode": false
     },
     {
+      "name": "Python: Debug Celery Tasks",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/manage.py",
+      "args": [
+        "runserver_plus",
+        "--print-sql",
+        "0.0.0.0:8000"
+      ],
+      "env": {
+        "DJANGO_CELERY_TASK_ALWAYS_EAGER": "true",
+      },
+      "django": true,
+      "justMyCode": false
+    },
+    {
       "name": "Python: Debug Tests",
       "type": "debugpy",
       "request": "launch",

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/development.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/development.py
@@ -55,3 +55,7 @@ OAUTH2_PROVIDER['REQUEST_APPROVAL_PROMPT'] = 'force'
 SHELL_PLUS_IMPORTS = [
     'from {{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }} import tasks',
 ]
+
+# Expose task_always_eager configurability via the environment for debugging purposes.
+CELERY_TASK_ALWAYS_EAGER = env.bool('DJANGO_CELERY_TASK_ALWAYS_EAGER', default=False)
+CELERY_TASK_EAGER_PROPAGATES = CELERY_TASK_ALWAYS_EAGER


### PR DESCRIPTION
@danlamanna this is intended to address the following comment from #320 

> Figure out to what extent we want to support [multiple containers](https://code.visualstudio.com/remote/advancedcontainers/connect-multiple-containers) for items like celery

If we like this approach, I think we should consider whether this merits its own launch configuration, or whether we should simply use `task_always_eager=True` by default on the Django Server launch config so there's just one debugging entrypoint to rule them all.

@brianhelba please evaluate whether my modifications to the development settings file make sense.