### PR TITLE
Add celerybeat-schedule.db to .gitignore

### DIFF
--- a/{{ cookiecutter.project_slug }}/.gitignore
+++ b/{{ cookiecutter.project_slug }}/.gitignore
@@ -1,4 +1,6 @@
-celerybeat-schedule*
+
+# Additional Celery Beat files
+celerybeat-schedule.db
 
 # Created by https://www.toptal.com/developers/gitignore/api/django,terraform
 # Edit at https://www.toptal.com/developers/gitignore?templates=django,terraform


### PR DESCRIPTION
According to Celery [docs](https://docs.celeryq.dev/en/stable/userguide/configuration.html#beat-schedule-filename), the [shelve](https://docs.python.org/3/library/shelve.html) module might (or might not?) append `.db` to the name. AFAICT it's appended `.db` for at least a decade. :man_shrugging:  

cc @mvandenburgh 