### PR TITLE
Use the `latest` MinIO image in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           - 5672:5672
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnamilegacy/minio:2025.4.22
+        image: bitnamilegacy/minio:latest
         env:
           MINIO_ROOT_USER: minioAccessKey
           MINIO_ROOT_PASSWORD: minioSecretKey

--- a/resonant-template/.github/workflows/ci.yml
+++ b/resonant-template/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - 5672:5672
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnamilegacy/minio:2025.4.22
+        image: bitnamilegacy/minio:latest
         env:
           MINIO_ROOT_USER: minioAccessKey
           MINIO_ROOT_PASSWORD: minioSecretKey


### PR DESCRIPTION
Reverts kitware-resonant/cookiecutter-resonant#334

Will apply when https://github.com/bitnami/containers/issues/81607 is fixed.