### PR TITLE
Use runserver_plus as the development server

### DIFF
--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -37,7 +37,7 @@ but allows developers to run Python code on their native system.
 1.  Ensure `docker compose -f ./docker-compose.yml up -d` is still active
 2. Run:
    1. `source ./dev/export-env.sh`
-   2. `./manage.py runserver`
+   2. `./manage.py runserver_plus`
 3. Run in a separate terminal:
    1. `source ./dev/export-env.sh`
    2. `celery --app {{ cookiecutter.pkg_name }}.celery worker --loglevel INFO --without-heartbeat`

--- a/{{ cookiecutter.project_slug }}/docker-compose.override.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.override.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: ./dev/django.Dockerfile
-    command: ["./manage.py", "runserver", "0.0.0.0:8000"]
+    command: ["./manage.py", "runserver_plus", "0.0.0.0:8000"]
     # Log printing via Rich is enhanced by a TTY
     tty: true
     env_file: ./dev/.env.docker-compose

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
   "django-s3-file-field[minio]",
   "ipython",
   "tox",
+  "watchdog",
   "werkzeug",
 ]
 

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/development.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/development.py
@@ -10,7 +10,7 @@ INSTALLED_APPS += [
     'debug_toolbar',
     'django_browser_reload',
 ]
-# Force WhiteNoice to serve static files, even when using 'manage.py runserver'
+# Force WhiteNoice to serve static files, even when using 'manage.py runserver_plus'
 staticfiles_index = INSTALLED_APPS.index('django.contrib.staticfiles')
 INSTALLED_APPS.insert(staticfiles_index, 'whitenoise.runserver_nostatic')
 


### PR DESCRIPTION
https://django-extensions.readthedocs.io/en/latest/runserver_plus.html