### PR TITLE
Fix test debugging in dev containers via IDE

### DIFF
--- a/{{ cookiecutter.project_slug }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.project_slug }}/.devcontainer/devcontainer.json
@@ -51,6 +51,7 @@
             "onAutoForward": "ignore"
         }
     },
+    "postCreateCommand": "uv sync --all-groups",
     "updateContentCommand": [
         "uv",
         "sync"

--- a/{{ cookiecutter.project_slug }}/docker-compose.override.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.override.yml
@@ -17,6 +17,8 @@ services:
       UV_PYTHON_INSTALL_DIR: /home/vscode/uv/bin
       # The uv cache and environment are on different volumes, so hardlinks won't work
       UV_LINK_MODE: copy
+    env_file:
+      - ./dev/.env.docker-compose
     working_dir: /home/vscode/django-project
     volumes:
       - .:/home/vscode/django-project


### PR DESCRIPTION
There were two separate problems that had broken integrated test launching after the `uv` changes. Firstly, the test-related dependencies were no longer installed by default. Secondly, the tests could not be run via the IDE because the required django env vars were no longer set in the dev container.

I have no idea whether these approaches are a sane way to fix these issues, but they do fix them. Someone who knows more about `uv`'s capabilities than me (@brianhelba) should take a look and comment on whether there's a better practice for this. For one, I suspect `postCreateCommand` is probably not the right lifecycle hook for performing this sync.