### PR TITLE
Revert attempt to use UV_ENV_FILE

### DIFF
--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -30,13 +30,13 @@ but allows developers to run Python code on their native system.
 ### Initial Setup
 1. Run `docker compose -f ./docker-compose.yml up -d`
 2. [Install `uv`](https://docs.astral.sh/uv/getting-started/installation/)
-3. Run `export UV_ENV_FILE=./dev/.env.docker-compose-native`
+3. Run `source ./dev/export-env.sh`
 4. Run `./manage.py migrate`
 5. Run `./manage.py createsuperuser` and follow the prompts to create your own user
 
 ### Run Application
 1. Ensure `docker compose -f ./docker-compose.yml up -d` is still active
-2. Run `export UV_ENV_FILE=./dev/.env.docker-compose-native`
+2. Run `source ./dev/export-env.sh`
 3. Run: `./manage.py runserver_plus`
 4. Run in a separate terminal: `uv run celery --app {{ cookiecutter.pkg_name }}.celery worker --loglevel INFO --without-heartbeat`
 5. When finished, run `docker compose stop`

--- a/{{ cookiecutter.project_slug }}/dev/export-env.sh
+++ b/{{ cookiecutter.project_slug }}/dev/export-env.sh
@@ -1,0 +1,29 @@
+# Export environment variables from the .env file in the first argument.
+# If no argument is given, default to "dev/.env.docker-compose-native".
+# This file must be sourced, not run.
+
+if [ -n "$1" ]; then
+  # If an argument was provided, use it as the .env file
+  _dotenv_file="$1"
+else
+  # Otherwise, use the default .env file
+  if [ -n "$ZSH_VERSION" ]; then
+    # ZSH has a different way to get the directory of the current script
+    _dotenv_dir="$0:A:h"
+  else
+    # Assume this is Bash
+    _dotenv_dir="$( dirname "${BASH_SOURCE[0]}" )"
+  fi
+  _dotenv_file="${_dotenv_dir}/.env.docker-compose-native"
+fi
+
+# Export all assignments in the $_dotenv_file
+# Using "set -a" allows .env files with spaces or comments to work seamlessly
+# https://stackoverflow.com/a/45971167
+set -a
+. "$_dotenv_file"
+set +a
+
+# Clean up, since sourcing this leaks any shell variables
+unset _dotenv_dir
+unset _dotenv_file

--- a/{{ cookiecutter.project_slug }}/docker-compose.override.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.override.yml
@@ -9,8 +9,7 @@ services:
     ]
     # Log printing is enhanced by a TTY
     tty: true
-    environment:
-      UV_ENV_FILE: ./dev/.env.docker-compose
+    env_file: ./dev/.env.docker-compose
     working_dir: /opt/django-project
     volumes:
       - .:/opt/django-project
@@ -39,8 +38,7 @@ services:
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors
     tty: false
-    environment:
-      UV_ENV_FILE: ./dev/.env.docker-compose
+    env_file: ./dev/.env.docker-compose
     working_dir: /opt/django-project
     volumes:
       - .:/opt/django-project


### PR DESCRIPTION
~When using Tox, it may be the case that commands are not invoked with `uv run`, so the envfile isn't getting loaded for commands run via Tox.~

Additionally, integration with VSCode and Pytest will not be run via `uv run`, so we can't rely on uv always getting the chance to set environment variables.