### PR TITLE
Remove automatic setting of `DJANGO_SETTINGS_MODULE` in `manage.py`

### DIFF
--- a/{{ cookiecutter.project_slug }}/manage.py
+++ b/{{ cookiecutter.project_slug }}/manage.py
@@ -1,15 +1,10 @@
 #!/usr/bin/env -S uv run
-import os
 import sys
 
 from django.core.management import execute_from_command_line
 
 
 def main() -> None:
-    # Production usage runs manage.py for tasks like collectstatic,
-    # so DJANGO_SETTINGS_MODULE should always be explicitly set in production
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{ cookiecutter.pkg_name }}.settings.development')
-
     execute_from_command_line(sys.argv)
 
 


### PR DESCRIPTION
Parsing settings is going to require other environment variables to be set, so this default doesn't make `manage.py` any more usable.