### PR TITLE
Properly exclude celerybeat related files

### DIFF
--- a/resonant-template/.gitignore
+++ b/resonant-template/.gitignore
@@ -1,6 +1,6 @@
 
 # Additional Celery Beat files
-celerybeat-schedule.*
+celerybeat-schedule*
 
 # Created by https://www.toptal.com/developers/gitignore/api/django,terraform
 # Edit at https://www.toptal.com/developers/gitignore?templates=django,terraform


### PR DESCRIPTION
Follow up to #351 and #330. See https://github.com/kitware-resonant/cookiecutter-resonant/pull/330#issuecomment-2938413198.