### PR TITLE
Fix cookiecutter typo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           uv run tox
         working-directory: django-resonant-settings
-  test-cookecutter:
+  test-cookiecutter:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The repo setting for required checks needs to be changed when this gets merged.