### PR TITLE
Add UPDATE_ON_FETCH to the debug toolbar settings

### DIFF
--- a/django-resonant-settings/resonant_settings/development/debug_toolbar.py
+++ b/django-resonant-settings/resonant_settings/development/debug_toolbar.py
@@ -10,4 +10,7 @@ DEBUG_TOOLBAR_CONFIG = {
     "RESULTS_CACHE_SIZE": 250,
     # If this setting is True, large sql queries can cause the page to render slowly
     "PRETTIFY_SQL": False,
+    # Updates the currently shown request to the most recent ajax request. This is useful
+    # for the swagger page, where all the requests that we care about are ajax requests.
+    "UPDATE_ON_FETCH": True,
 }


### PR DESCRIPTION
This will result in the the debug toolbar being more effective on the swagger page.