### PR TITLE
Add i18n configuration

### DIFF
--- a/django-resonant-settings/resonant_settings/django.py
+++ b/django-resonant-settings/resonant_settings/django.py
@@ -33,3 +33,10 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
+
+# Internationalization
+# https://docs.djangoproject.com/en/5.0/topics/i18n/
+USE_TZ = True
+# Internal datetimes are timezone-aware, so this only affects rendering and form input
+TIME_ZONE = "UTC"
+USE_I18N = True

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/base.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings/base.py
@@ -69,9 +69,6 @@ MIDDLEWARE = [
     'allauth.account.middleware.AccountMiddleware',
 ]
 
-# Internal datetimes are timezone-aware, so this only affects rendering and form input
-TIME_ZONE = 'UTC'
-
 DATABASES = {
     'default': {
         **env.db_url('DJANGO_DATABASE_URL', engine='django.db.backends.postgresql'),


### PR DESCRIPTION
These settings were previously set by `django-composed-configuration`, but are not currently included in `django-resonant-settings`. Fixes #367 