### PR TITLE
Change AWS_QUERYSTRING_EXPIRE to integer type

### DIFF
--- a/django-resonant-settings/resonant_settings/production/s3_storage.py
+++ b/django-resonant-settings/resonant_settings/production/s3_storage.py
@@ -28,4 +28,4 @@ AWS_S3_SIGNATURE_VERSION = "s3v4"
 
 AWS_S3_MAX_MEMORY_SIZE = 5 * 1024 * 1024
 AWS_S3_FILE_OVERWRITE = False
-AWS_QUERYSTRING_EXPIRE = timedelta(hours=6).total_seconds()
+AWS_QUERYSTRING_EXPIRE = int(timedelta(hours=6).total_seconds())


### PR DESCRIPTION
The `total_seconds` method of a `timedelta` returns a float. This gets encoded in the presigned URL strings as`X-Amz-Expires=21600.0`, which AWS S3 rejects with the following message:

```xml
<Error>
<Code>AuthorizationQueryParametersError</Code>
<Message>X-Amz-Expires should be a number</Message>
<RequestId>ME54E3EF38K7PZKT</RequestId>
<HostId>Qz59L0WIiPX+p5bP3IZuCs7TLFigfaFzerZdo4WO63mGdUkP0ghQeLflDYvBIo7LtwJl8bd710M=</HostId>
</Error>
```