### PR TITLE
Cast `AWS_QUERYSTRING_EXPIRE` to int

### DIFF
--- a/django-resonant-settings/resonant_settings/production/s3_storage.py
+++ b/django-resonant-settings/resonant_settings/production/s3_storage.py
@@ -28,4 +28,4 @@ AWS_S3_SIGNATURE_VERSION = "s3v4"
 
 AWS_S3_MAX_MEMORY_SIZE = 5 * 1024 * 1024
 AWS_S3_FILE_OVERWRITE = False
-AWS_QUERYSTRING_EXPIRE = timedelta(hours=6).total_seconds()
+AWS_QUERYSTRING_EXPIRE = int(timedelta(hours=6).total_seconds())


### PR DESCRIPTION
This value should be an `int` according to https://boto3.amazonaws.com/v1/documentation/api/1.17.93/reference/services/s3.html#S3.Client.generate_presigned_url. 

Currently, we are encountering errors with presigned URLs on DANDI due to this. See https://api.sandbox.dandiarchive.org/api/assets/ad5d6b54-9974-4559-b400-88b406be983d/download/ for an example.