### PR TITLE
Remove --verbose from pytest configuration

### DIFF
--- a/resonant-template/pyproject.toml.jinja
+++ b/resonant-template/pyproject.toml.jinja
@@ -200,7 +200,6 @@ addopts = [
   "--strict-config",
   "--strict-markers",
   "--showlocals",
-  "--verbose",
   # Specifying as "--ds" will override any value in the environment
   "--ds={{ python_package_name }}.settings.testing",
 ]


### PR DESCRIPTION
I recently removed this from ISIC because I've found that it gets particularly noisy after adding a lot of tests. It also doesn't add any information during the failure of a test. Thoughts @brianhelba @mvandenburgh?