### PR TITLE
Disable `ACCOUNT_CONFIRM_EMAIL_ON_GET`

### DIFF
--- a/django-resonant-settings/resonant_settings/allauth.py
+++ b/django-resonant-settings/resonant_settings/allauth.py
@@ -49,15 +49,11 @@ ACCOUNT_SESSION_REMEMBER = True
 ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = True
 ACCOUNT_LOGIN_ON_PASSWORD_RESET = True
 
-# Confirm URLs include a secret token, so CSRF safety isn't a concern
-ACCOUNT_CONFIRM_EMAIL_ON_GET = True
-
 # This will likely become the default in the future, but enable it now
 ACCOUNT_PRESERVE_USERNAME_CASING = False
 
 __all__ = [
     "ACCOUNT_ADAPTER",
-    "ACCOUNT_CONFIRM_EMAIL_ON_GET",
     "ACCOUNT_EMAIL_VERIFICATION",
     "ACCOUNT_LOGIN_METHODS",
     "ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION",


### PR DESCRIPTION
Some email scanners will load this link, causing confirmation before the user actually visits.

This is only visited once per user, so the extra inconvenience shouldn't be a problem, compared to the security issue of the scanner causing confirmation and the user confusion if they visit a redeemed link.