### PR TITLE
Prevent unnecessary Python venv activation in dev container terminals

### DIFF
--- a/resonant-template/.devcontainer/devcontainer.json.jinja
+++ b/resonant-template/.devcontainer/devcontainer.json.jinja
@@ -53,6 +53,8 @@
         "containers.containerClient": "com.microsoft.visualstudio.containers.docker",
         // Container-specific Python paths
         "python.defaultInterpreterPath": "/home/vscode/venv/bin/python",
+        // Disable automatic Python venv activation in new terminals.
+        "python-envs.terminal.autoActivationType": "off",
         // Ensure that `envFile` from any user settings is ignored; Docker Compose provides it.
         "python.envFile": "",
         // Reduce file watcher overhead for generated/cache directories.


### PR DESCRIPTION

The Microsoft Python VSCode extension will now automatically install Python Environments.
If there is no pre-configured setting to disable Python environments, it will randomly assign it to be turned on or off.

https://marketplace.visualstudio.com/items?itemName=ms-python.python
<img width="1582" height="910" alt="image" src="https://github.com/user-attachments/assets/5fa735c9-7c21-4baf-937a-8e9a7c1059ae" />
The page references using `"python.useEnvironmentsExtension": true || false)` in the settings to disable this.  In practice on two machines, this didn't disable the auto-venv activation.

[Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) itself has a configuration parameter: `terminal.autoActivationType` that defaults to `'command'` but can be configured to `'off'`.  Testing with `'off'` will disable the auto-venv activation for regular VS Code and within dev containers.
