### PR TITLE
Revert "Allow the "Pytest: Debug" launch config to be run directly"

### DIFF
--- a/resonant-template/.vscode/launch.json.jinja
+++ b/resonant-template/.vscode/launch.json.jinja
@@ -72,7 +72,6 @@
       "name": "Pytest: Debug",
       "type": "debugpy",
       "request": "launch",
-      "module": "pytest",
       "purpose": ["debug-test"],
       "console": "integratedTerminal",
       "django": true,


### PR DESCRIPTION
Reverts kitware-resonant/cookiecutter-resonant#467

Newer versions of VSCode merge an internal launch configuration with this one, resulting in errors like:
> Invalid message: "program", "module", and "code" are mutually exclusive

This particular launch configuration is now hidden from the launch menu anyway, so making it not directly runnable should not longer matter.