### PR TITLE
Remove `min_version` from `tox.ini`

### DIFF
--- a/django-resonant-settings/tox.ini
+++ b/django-resonant-settings/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-min_version = 4.22
 requires =
     tox-uv
 env_list =

--- a/resonant-template/tox.ini.jinja
+++ b/resonant-template/tox.ini.jinja
@@ -1,5 +1,4 @@
 [tox]
-min_version = 4.22
 requires =
     tox-uv
 env_list =


### PR DESCRIPTION
The option is deprecated in favor of `requires`, but uv and Renovate ensure that we'll have a modern version of Tox, so omit it for simplicity.