### PR TITLE
Remove the dev container feature for Git LFS

### DIFF
--- a/resonant-template/.devcontainer/devcontainer.json.jinja
+++ b/resonant-template/.devcontainer/devcontainer.json.jinja
@@ -12,7 +12,6 @@
   // The "vscode" user and remoteUser are set by the base image label (devcontainers/base).
   "workspaceFolder": "/home/vscode/{{ project_slug }}",
   "features": {
-    "ghcr.io/devcontainers/features/git-lfs:1": {},
     "ghcr.io/devcontainers/features/node:2.1": {
       "version": "24"
     },


### PR DESCRIPTION
It's not used as a baseline by most projects.

The current bandwidth limits when using Git LFS with GitHub make it a poor choice in many cases.