### PR TITLE
More reliably disable IPv6 in dev containers

### DIFF
--- a/resonant-template/dev/django.Dockerfile.jinja
+++ b/resonant-template/dev/django.Dockerfile.jinja
@@ -5,8 +5,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 # Ensure Python output appears immediately in container logs.
 ENV PYTHONUNBUFFERED=1
 
-# Override Node's default of attempting to bind to IPv6 interfaces over IPv4
-ENV NODE_OPTIONS=--dns-result-order=ipv4first
+# Override Node's default of attempting to bind to IPv6 interfaces over IPv4.
+# VSCode "node" launch configs override "NODE_OPTIONS", so use "NPM_CONFIG_NODE_OPTIONS".
+ENV NPM_CONFIG_NODE_OPTIONS=--dns-result-order=ipv4first
 
 # Put the uv and npm caches in a separate location,
 # where they can persist and be shared across containers.


### PR DESCRIPTION
VSCode contends for setting the `NODE_OPTIONS` env var.